### PR TITLE
Trim ending whitespace on `read_line`

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -21,6 +21,7 @@ pub(crate) fn read_input<I: Io>(prompt: &str, io: &mut I) -> Result<String> {
     write!(io.stdout(), "{prompt}: ")?;
     io.stdout().flush()?;
     io.stdin().read_line(&mut input)?;
+    input.truncate(input.trim_end().len());
     Ok(input)
 }
 


### PR DESCRIPTION
Logging in was failing for me and after debugging I discovered that it was because of `\n` being present in the Strings from `read_line`.

This fixes it.